### PR TITLE
Force Retry Delay

### DIFF
--- a/jms-reactive-client/src/main/java/edu/psu/activemq/MessageProcessor.java
+++ b/jms-reactive-client/src/main/java/edu/psu/activemq/MessageProcessor.java
@@ -281,7 +281,17 @@ public abstract class MessageProcessor {
     return msg;
   }
 
+  /*
+  * long calculateRetryWait(int retryCount, UnableToProcessMessageException upme)
+  * if UnableToProcessMessageException.forceOffset is set as GT 0, then that value is used for the retryWait
+  * used for when systems are down and tell us when they'll be back online (ie. workday)
+  */
   public long calculateRetryWait(int retryCount, UnableToProcessMessageException upme) {
+    // force offset will retryWait that amount
+    if (upme.getForceOffset() != null && upme.getForceOffset() > 0) {
+      return upme.getForceOffset().longValue();
+    } 
+
     // Assume linear
     long retryWait = upme.getRetryWait();
 

--- a/jms-reactive-client/src/main/java/edu/psu/activemq/MessageProcessor.java
+++ b/jms-reactive-client/src/main/java/edu/psu/activemq/MessageProcessor.java
@@ -283,13 +283,13 @@ public abstract class MessageProcessor {
 
   /*
   * long calculateRetryWait(int retryCount, UnableToProcessMessageException upme)
-  * if UnableToProcessMessageException.forceOffset is set as GT 0, then that value is used for the retryWait
+  * if UnableToProcessMessageException.ForceRetryWaitDelay is set as GT 0, then that value is used for the retryWait
   * used for when systems are down and tell us when they'll be back online (ie. workday)
   */
   public long calculateRetryWait(int retryCount, UnableToProcessMessageException upme) {
     // force offset will retryWait that amount
-    if (upme.getForceOffset() != null && upme.getForceOffset() > 0) {
-      return upme.getForceOffset().longValue();
+    if (upme.getForceRetryWaitDelay() != null && upme.getForceRetryWaitDelay() > 0) {
+      return upme.getForceRetryWaitDelay().longValue();
     } 
 
     // Assume linear

--- a/jms-reactive-client/src/main/java/edu/psu/activemq/MessageProcessor.java
+++ b/jms-reactive-client/src/main/java/edu/psu/activemq/MessageProcessor.java
@@ -287,11 +287,6 @@ public abstract class MessageProcessor {
   * used for when systems are down and tell us when they'll be back online (ie. workday)
   */
   public long calculateRetryWait(int retryCount, UnableToProcessMessageException upme) {
-    // force offset will retryWait that amount
-    if (upme.getForceRetryWaitDelay() != null && upme.getForceRetryWaitDelay() > 0) {
-      return upme.getForceRetryWaitDelay().longValue();
-    } 
-
     // Assume linear
     long retryWait = upme.getRetryWait();
 
@@ -299,6 +294,11 @@ public abstract class MessageProcessor {
     if (initialOffset == null) {
       initialOffset = 0;
     }
+
+    // force initial offset will retryWait that amount
+    if (upme.isForceInitialOffsetDelay()) {
+      return initialOffset.longValue();
+    } 
 
     if (retryCount == 1 && initialOffset > 0) {
       retryWait = initialOffset.longValue();

--- a/jms-reactive-client/src/main/java/edu/psu/activemq/exception/UnableToProcessMessageException.java
+++ b/jms-reactive-client/src/main/java/edu/psu/activemq/exception/UnableToProcessMessageException.java
@@ -59,7 +59,7 @@ public class UnableToProcessMessageException extends RuntimeException {
 
   @Getter
   @Setter
-  Integer forceRetryWaitDelay = 0;
+  boolean forceInitialOffsetDelay = false;
 
   private static final long serialVersionUID = 1497512404523880592L;
 

--- a/jms-reactive-client/src/main/java/edu/psu/activemq/exception/UnableToProcessMessageException.java
+++ b/jms-reactive-client/src/main/java/edu/psu/activemq/exception/UnableToProcessMessageException.java
@@ -57,6 +57,10 @@ public class UnableToProcessMessageException extends RuntimeException {
   @Setter
   Integer initialOffset = 0;
 
+  @Getter
+  @Setter
+  Integer forceOffset = 0;
+
   private static final long serialVersionUID = 1497512404523880592L;
 
   public UnableToProcessMessageException(String why) {

--- a/jms-reactive-client/src/main/java/edu/psu/activemq/exception/UnableToProcessMessageException.java
+++ b/jms-reactive-client/src/main/java/edu/psu/activemq/exception/UnableToProcessMessageException.java
@@ -59,7 +59,7 @@ public class UnableToProcessMessageException extends RuntimeException {
 
   @Getter
   @Setter
-  Integer forceOffset = 0;
+  Integer forceRetryWaitDelay = 0;
 
   private static final long serialVersionUID = 1497512404523880592L;
 

--- a/jms-reactive-client/src/main/java/edu/psu/activemq/util/RetryExceptionUtil.java
+++ b/jms-reactive-client/src/main/java/edu/psu/activemq/util/RetryExceptionUtil.java
@@ -32,16 +32,16 @@ public class RetryExceptionUtil {
     return createRetryBackoffException(message);
   }
   
-  public static UnableToProcessMessageException createRetryException(String message, int retryAmount) {
-    return createRetryBackoffException(message, retryAmount);
+  public static UnableToProcessMessageException createRetryException(String message, int retryWait) {
+    return createRetryBackoffException(message, retryWait);
   }
   
   public static UnableToProcessMessageException createRetryException(String message, Exception e) {
     return createRetryBackoffException(message, e);
   }
   
-  public static UnableToProcessMessageException createRetryException(String message, Exception e, int retryAmount) {
-    return createRetryBackOffException(message, e, retryAmount);
+  public static UnableToProcessMessageException createRetryException(String message, Exception e, int retryWait) {
+    return createRetryBackOffException(message, e, retryWait);
   }
   
 
@@ -52,9 +52,9 @@ public class RetryExceptionUtil {
     return utpe;
   }
   
-  public static UnableToProcessMessageException createRetryBackoffException(String message, int retryAmount) {
+  public static UnableToProcessMessageException createRetryBackoffException(String message, int retryWait) {
     UnableToProcessMessageException utpe = new UnableToProcessMessageException(message);
-    utpe.setRetry(retryAmount);
+    utpe.setRetry(retryWait);
     utpe.setRetryStyle(RetryStyle.EXPONENTIAL);
     return utpe;
   }
@@ -66,25 +66,25 @@ public class RetryExceptionUtil {
     return utpe;
   }
   
-  public static UnableToProcessMessageException createRetryBackOffException(String message, Exception e, int retryAmount) {
+  public static UnableToProcessMessageException createRetryBackOffException(String message, Exception e, int retryWait) {
     UnableToProcessMessageException utpe = new UnableToProcessMessageException(message, e);
-    utpe.setRetry(retryAmount);
+    utpe.setRetry(retryWait);
     utpe.setRetryStyle(RetryStyle.EXPONENTIAL);
     return utpe;
   }
   
-  public static UnableToProcessMessageException createRetryBackOffException(String message, int retryAmount, double backOffMultiplier, int numberOfRetries) {
+  public static UnableToProcessMessageException createRetryBackOffException(String message, int retryWait, double backOffMultiplier, int numberOfRetries) {
     UnableToProcessMessageException utpe = new UnableToProcessMessageException(message);
-    utpe.setRetry(retryAmount);
+    utpe.setRetry(retryWait);
     utpe.setRetryStyle(RetryStyle.EXPONENTIAL);
     utpe.setBackOffMultiplier(backOffMultiplier);
     utpe.setNumberOfRetries(numberOfRetries);
     return utpe;
   }
   
-  public static UnableToProcessMessageException createRetryBackOffException(String message, Exception e, int retryAmount, double backOffMultiplier, int numberOfRetries) {
+  public static UnableToProcessMessageException createRetryBackOffException(String message, Exception e, int retryWait, double backOffMultiplier, int numberOfRetries) {
     UnableToProcessMessageException utpe = new UnableToProcessMessageException(message, e);
-    utpe.setRetry(retryAmount);
+    utpe.setRetry(retryWait);
     utpe.setRetryStyle(RetryStyle.EXPONENTIAL);
     utpe.setBackOffMultiplier(backOffMultiplier);
     utpe.setNumberOfRetries(numberOfRetries);
@@ -97,9 +97,9 @@ public class RetryExceptionUtil {
     return utpe;
   }
   
-  public static UnableToProcessMessageException createRetryNonBackoffException(String message, int retryAmount) {
+  public static UnableToProcessMessageException createRetryNonBackoffException(String message, int retryWait) {
     UnableToProcessMessageException utpe = new UnableToProcessMessageException(message);
-    utpe.setRetry(retryAmount);
+    utpe.setRetry(retryWait);
     return utpe;
   }
   
@@ -109,9 +109,9 @@ public class RetryExceptionUtil {
     return utpe;
   }
   
-  public static UnableToProcessMessageException createRetryNonBackoffException(String message, Exception e, int retryAmount) {
+  public static UnableToProcessMessageException createRetryNonBackoffException(String message, Exception e, int retryWait) {
     UnableToProcessMessageException utpe = new UnableToProcessMessageException(message, e);
-    utpe.setRetry(retryAmount);
+    utpe.setRetry(retryWait);
     return utpe;
   }
   


### PR DESCRIPTION
With workday outages, we noticed that if retryCount is above 1 then it didn't wait until workday outage was over.  Adding a new variable to accomplish this workflow